### PR TITLE
Fix UVM sequencer-driver connection error

### DIFF
--- a/env/int_subenv.sv
+++ b/env/int_subenv.sv
@@ -38,7 +38,7 @@ class int_subenv extends soc_base_subenv;
         m_monitor.item_collected_port.connect(m_coverage.analysis_export);
 
         // Connect sequencer to driver
-        m_sequencer.seq_item_port.connect(m_driver.seq_item_export);
+        m_driver.seq_item_port.connect(m_sequencer.seq_item_export);
     endfunction
 
 endclass


### PR DESCRIPTION
## Problem
Fixed compilation error in `env/int_subenv.sv` line 41:
```
Error-[MFNF] Member not found
Could not find member 'seq_item_port' in class 'int_sequencer'
```

## Root Cause
The connection between sequencer and driver was incorrect:
```systemverilog
// Incorrect - sequencer doesn't have seq_item_port
m_sequencer.seq_item_port.connect(m_driver.seq_item_export);
```

## Solution
Fixed the connection to follow standard UVM pattern:
```systemverilog
// Correct - driver's port connects to sequencer's export
m_driver.seq_item_port.connect(m_sequencer.seq_item_export);
```

## Technical Details
- `uvm_sequencer` provides `seq_item_export` (export port)
- `uvm_driver` provides `seq_item_port` (pull port)
- Standard UVM connection: `driver.seq_item_port.connect(sequencer.seq_item_export)`
- This allows the driver to pull sequence items from the sequencer

## Testing
- [x] Code compiles without the member not found error
- [x] Follows UVM best practices for sequencer-driver connections

## Files Changed
- `env/int_subenv.sv`: Fixed sequencer-driver connection in `connect_phase()`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author