### PR TITLE
Fix: Correct return type of get_merge_sources function

### DIFF
--- a/seq/int_routing_model.sv
+++ b/seq/int_routing_model.sv
@@ -20,7 +20,7 @@ class int_routing_model;
     endfunction
 
     // Function to get all source interrupts that should be merged into a specific merge interrupt
-    static function interrupt_info_s get_merge_sources(string merge_interrupt_name, ref interrupt_info_s sources[$]);
+    static function int get_merge_sources(string merge_interrupt_name, ref interrupt_info_s sources[$]);
         sources.delete();
 
         case (merge_interrupt_name)


### PR DESCRIPTION
## Problem

SystemVerilog compilation was failing with error:
```
Error-[ICTA] Incompatible complex type
/share/project/greenland/dev/wenbo.liu/ws3/dv/iosub/soc_top/subenv/int_subenv/seq/int_lightweight_sequence.sv, 112
  Incompatible complex type assignment
  Type of source expression is incompatible with type of target expression. 
  Mismatching types cannot be used in assignments, initializations and 
  instantiations. The type of the target is 'int', while the type of the 
  source is 'struct int_subenv_pkg::interrupt_info_s'.
  Source Expression: int_routing_model::get_merge_sources(merge_info.name, source_interrupts)
```

## Root Cause

The `get_merge_sources` function had a type mismatch:
- **Function declaration**: `static function interrupt_info_s get_merge_sources(...)` - declared to return a struct
- **Function implementation**: `return sources.size();` - actually returns an integer
- **Usage**: `num_sources = int_routing_model::get_merge_sources(...)` - expects an integer

## Solution

Changed the function declaration in `seq/int_routing_model.sv` from:
```systemverilog
static function interrupt_info_s get_merge_sources(string merge_interrupt_name, ref interrupt_info_s sources[$]);
```

To:
```systemverilog
static function int get_merge_sources(string merge_interrupt_name, ref interrupt_info_s sources[$]);
```

## Why This Fix is Correct

1. **Function Logic**: The function populates the `sources` array via reference parameter and returns the count
2. **Implementation Consistency**: Function returns `sources.size()` which is an integer
3. **Usage Consistency**: All calling code expects integer return value (verified across codebase)
4. **Backward Compatibility**: No breaking changes - all existing code works as expected

## Files Changed

- `seq/int_routing_model.sv`: Fixed function return type declaration

## Testing

- Verified all calling sites expect `int` return type
- Function implementation already returns `sources.size()` (integer)
- No functional changes, only type declaration correction

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author