### PR TITLE
Fix iosub_abnormal merge signal UVM_ERROR issues

### DIFF
--- a/docs/fix_iosub_abnormal_merge_signals.md
+++ b/docs/fix_iosub_abnormal_merge_signals.md
@@ -1,0 +1,160 @@
+# 修复 iosub_abnormal 信号 UVM_ERROR 问题
+
+## 问题描述
+
+在仿真过程中出现了以下两个 UVM_ERROR：
+
+```
+120:12994:UVM_ERROR /share/tools/eda1/synopsys/vcs-2024.09-sp1/etc/uvm-1.2/src/dpi/uvm_hdl_vcs.c(1416) @ 92895.00ns: reporter [UVM/DPI/HDL_SET] set: unable to locate hdl path (top_tb.multidie_top.DUT[0].u_str_top.u_iosub_top_wrap.u0_iosub_top_wrap_hd.u0_iosub_top_wrap_raw.u_iosub_int_sub.iosub_peri_intr[74])
+
+120:12994:UVM_ERROR /share/tools/eda1/synopsys/vcs-2024.09-sp1/etc/uvm-1.2/src/dpi/uvm_hdl_vcs.c(1416) @ 92895.00ns: reporter [UVM/DPI/HDL_SET] set: unable to locate hdl path (top_tb.multidie_top.DUT[0].u_str_top.u_iosub_top_wrap.u0_iosub_top_wrap_hd.u0_iosub_top_wrap_raw.u_iosub_int_sub.iosub_peri_intr[75])
+```
+
+## 根本原因分析
+
+1. **问题1**: `iosub_abnormal_0_intr` (index 74) 已经被配置为merge类信号，但系统仍然尝试直接force/release其RTL路径，导致HDL路径定位失败。
+
+2. **问题2**: `iosub_abnormal_1_intr` (index 75) 应该也被添加为merge类信号，但由于属于reserved信号（没有对应的源信号），需要特殊处理。
+
+## 解决方案
+
+### 1. 更新路由模型 (seq/int_routing_model.sv)
+
+#### 添加 iosub_abnormal_1_intr 的merge处理逻辑：
+
+```systemverilog
+"iosub_abnormal_1_intr": begin
+    // iosub_abnormal_1_intr is a reserved merge signal with no sources
+    // This is intentionally empty as it's reserved for future use
+    // No sources to collect for this merge signal
+end
+```
+
+#### 更新 is_merge_interrupt 函数：
+
+```systemverilog
+// Function to check if an interrupt is a merge interrupt
+static function bit is_merge_interrupt(string interrupt_name);
+    return (interrupt_name == "merge_pll_intr_lock" ||
+            interrupt_name == "merge_pll_intr_unlock" ||
+            interrupt_name == "merge_pll_intr_frechangedone" ||
+            interrupt_name == "merge_pll_intr_frechange_tot_done" ||
+            interrupt_name == "merge_pll_intr_intdocfrac_err" ||
+            // New merge interrupts from CSV analysis
+            interrupt_name == "iosub_normal_intr" ||
+            interrupt_name == "iosub_slv_err_intr" ||
+            interrupt_name == "iosub_ras_cri_intr" ||
+            interrupt_name == "iosub_ras_eri_intr" ||
+            interrupt_name == "iosub_ras_fhi_intr" ||
+            interrupt_name == "iosub_abnormal_0_intr" ||
+            interrupt_name == "iosub_abnormal_1_intr" ||  // 新增
+            interrupt_name == "merge_external_pll_intr");
+endfunction
+```
+
+### 2. 更新驱动器 (env/int_driver.sv)
+
+#### 添加merge信号检查逻辑：
+
+```systemverilog
+// Check if this is a merge interrupt - merge interrupts should not be directly stimulated
+if (is_merge_interrupt(item.interrupt_info.name)) begin
+    `uvm_warning(get_type_name(), $sformatf("⚠️  Interrupt '%s' is a merge signal. Merge signals should not be directly stimulated. Skipping stimulus generation.",
+                 item.interrupt_info.name));
+    `uvm_info(get_type_name(), "💡 To test merge signals, stimulate their source interrupts instead.", UVM_MEDIUM)
+    return;
+end
+```
+
+#### 添加 is_merge_interrupt 函数：
+
+```systemverilog
+// Function to check if an interrupt is a merge interrupt
+// Merge interrupts should not be directly stimulated
+virtual function bit is_merge_interrupt(string interrupt_name);
+    return (interrupt_name == "merge_pll_intr_lock" ||
+            interrupt_name == "merge_pll_intr_unlock" ||
+            interrupt_name == "merge_pll_intr_frechangedone" ||
+            interrupt_name == "merge_pll_intr_frechange_tot_done" ||
+            interrupt_name == "merge_pll_intr_intdocfrac_err" ||
+            // New merge interrupts from CSV analysis
+            interrupt_name == "iosub_normal_intr" ||
+            interrupt_name == "iosub_slv_err_intr" ||
+            interrupt_name == "iosub_ras_cri_intr" ||
+            interrupt_name == "iosub_ras_eri_intr" ||
+            interrupt_name == "iosub_ras_fhi_intr" ||
+            interrupt_name == "iosub_abnormal_0_intr" ||
+            interrupt_name == "iosub_abnormal_1_intr" ||
+            interrupt_name == "merge_external_pll_intr");
+endfunction
+```
+
+### 3. 更新验证脚本 (tools/verify_merge_implementation.py)
+
+#### 添加 iosub_abnormal_1_intr 到预期merge列表：
+
+```python
+"iosub_abnormal_1_intr": [
+    # Reserved merge signal with no sources
+    # This is intentionally empty as it's reserved for future use
+],
+```
+
+### 4. 更新测试文件 (test/tc_comprehensive_merge_test.sv)
+
+#### 添加到merge信号列表：
+
+```systemverilog
+all_merge_interrupts = {
+    // ... 其他信号 ...
+    "iosub_abnormal_0_intr",
+    "iosub_abnormal_1_intr",  // 新增
+    "merge_external_pll_intr"
+};
+```
+
+#### 添加验证函数：
+
+```systemverilog
+virtual function bit verify_abnormal_1_sources(interrupt_info_s sources[$]);
+    // iosub_abnormal_1_intr is a reserved merge signal with no sources
+    // Verify that it has no sources (empty list)
+    if (sources.size() == 0) begin
+        `uvm_info("COMP_MERGE_SEQ", "✅ iosub_abnormal_1_intr correctly has no sources (reserved)", UVM_MEDIUM)
+        return 1;
+    end else begin
+        `uvm_warning("COMP_MERGE_SEQ", $sformatf("iosub_abnormal_1_intr should have no sources but found %0d", sources.size()))
+        return 0;
+    end
+endfunction
+```
+
+## 修改的文件列表
+
+1. `seq/int_routing_model.sv` - 添加merge信号处理逻辑
+2. `env/int_driver.sv` - 添加merge信号检查，防止直接force/release
+3. `tools/verify_merge_implementation.py` - 更新验证脚本
+4. `test/tc_comprehensive_merge_test.sv` - 更新测试覆盖
+5. `tools/verify_merge_signal_handling.py` - 新增验证脚本
+
+## 验证结果
+
+运行验证脚本 `tools/verify_merge_signal_handling.py` 确认：
+
+✅ 所有merge信号已正确配置在路由模型中  
+✅ 驱动器包含merge信号检查逻辑  
+✅ 测试文件包含所有merge信号的覆盖  
+✅ iosub_abnormal_0_intr 和 iosub_abnormal_1_intr 配置正确  
+
+## 预期效果
+
+1. **解决UVM_ERROR**: merge信号不再被直接force/release，避免HDL路径定位错误
+2. **正确的merge信号处理**: 通过源信号来测试merge信号的功能
+3. **完整的测试覆盖**: 包含所有merge信号的测试验证
+4. **Reserved信号处理**: iosub_abnormal_1_intr作为reserved信号被正确处理
+
+## 使用说明
+
+- 要测试 `iosub_abnormal_0_intr`，应该刺激其源信号：`iodap_etr_buf_intr` 和 `iodap_catu_addrerr_intr`
+- `iosub_abnormal_1_intr` 作为reserved信号，暂时没有源信号，但已配置为merge信号以备将来使用
+- 驱动器会自动检测并跳过对merge信号的直接刺激，并给出相应的警告信息

--- a/env/int_driver.sv
+++ b/env/int_driver.sv
@@ -48,6 +48,14 @@ class int_driver extends uvm_driver #(int_stimulus_item);
             return;
         end
 
+        // Check if this is a merge interrupt - merge interrupts should not be directly stimulated
+        if (is_merge_interrupt(item.interrupt_info.name)) begin
+            `uvm_warning(get_type_name(), $sformatf("⚠️  Interrupt '%s' is a merge signal. Merge signals should not be directly stimulated. Skipping stimulus generation.",
+                         item.interrupt_info.name));
+            `uvm_info(get_type_name(), "💡 To test merge signals, stimulate their source interrupts instead.", UVM_MEDIUM)
+            return;
+        end
+
         // Show expected destinations for this interrupt
         `uvm_info(get_type_name(), "Expected destinations for this interrupt:", UVM_MEDIUM)
         if (item.interrupt_info.to_ap) `uvm_info(get_type_name(), $sformatf("  ✅ AP: %s", item.interrupt_info.rtl_path_ap), UVM_MEDIUM);
@@ -198,6 +206,25 @@ class int_driver extends uvm_driver #(int_stimulus_item);
         `uvm_info(get_type_name(), $sformatf("Cleared interrupt stimulus for '%s'", info.name), UVM_HIGH)
         #(timing_cfg.clear_propagation_delay_ns * 1ns); // Configurable propagation delay
     endtask
+
+    // Function to check if an interrupt is a merge interrupt
+    // Merge interrupts should not be directly stimulated
+    virtual function bit is_merge_interrupt(string interrupt_name);
+        return (interrupt_name == "merge_pll_intr_lock" ||
+                interrupt_name == "merge_pll_intr_unlock" ||
+                interrupt_name == "merge_pll_intr_frechangedone" ||
+                interrupt_name == "merge_pll_intr_frechange_tot_done" ||
+                interrupt_name == "merge_pll_intr_intdocfrac_err" ||
+                // New merge interrupts from CSV analysis
+                interrupt_name == "iosub_normal_intr" ||
+                interrupt_name == "iosub_slv_err_intr" ||
+                interrupt_name == "iosub_ras_cri_intr" ||
+                interrupt_name == "iosub_ras_eri_intr" ||
+                interrupt_name == "iosub_ras_fhi_intr" ||
+                interrupt_name == "iosub_abnormal_0_intr" ||
+                interrupt_name == "iosub_abnormal_1_intr" ||
+                interrupt_name == "merge_external_pll_intr");
+    endfunction
 
 endclass
 

--- a/seq/int_routing_model.sv
+++ b/seq/int_routing_model.sv
@@ -207,6 +207,12 @@ class int_routing_model;
                 end
             end
 
+            "iosub_abnormal_1_intr": begin
+                // iosub_abnormal_1_intr is a reserved merge signal with no sources
+                // This is intentionally empty as it's reserved for future use
+                // No sources to collect for this merge signal
+            end
+
             "merge_external_pll_intr": begin
                 // Collect all external PLL interrupts that should be merged
                 foreach (interrupt_map[i]) begin
@@ -250,6 +256,7 @@ class int_routing_model;
                 interrupt_name == "iosub_ras_eri_intr" ||
                 interrupt_name == "iosub_ras_fhi_intr" ||
                 interrupt_name == "iosub_abnormal_0_intr" ||
+                interrupt_name == "iosub_abnormal_1_intr" ||
                 interrupt_name == "merge_external_pll_intr");
     endfunction
 

--- a/test/tc_comprehensive_merge_test.sv
+++ b/test/tc_comprehensive_merge_test.sv
@@ -47,7 +47,7 @@ class comprehensive_merge_sequence extends int_base_sequence;
         all_merge_interrupts = {
             // Original PLL merge interrupts
             "merge_pll_intr_lock",
-            "merge_pll_intr_unlock", 
+            "merge_pll_intr_unlock",
             "merge_pll_intr_frechangedone",
             "merge_pll_intr_frechange_tot_done",
             "merge_pll_intr_intdocfrac_err",
@@ -58,6 +58,7 @@ class comprehensive_merge_sequence extends int_base_sequence;
             "iosub_ras_eri_intr",
             "iosub_ras_fhi_intr",
             "iosub_abnormal_0_intr",
+            "iosub_abnormal_1_intr",
             "merge_external_pll_intr"
         };
         
@@ -125,6 +126,7 @@ class comprehensive_merge_sequence extends int_base_sequence;
             "iosub_ras_eri_intr": test_passed &= verify_ras_eri_sources(merge_sources);
             "iosub_ras_fhi_intr": test_passed &= verify_ras_fhi_sources(merge_sources);
             "iosub_abnormal_0_intr": test_passed &= verify_abnormal_sources(merge_sources);
+            "iosub_abnormal_1_intr": test_passed &= verify_abnormal_1_sources(merge_sources);
             "merge_external_pll_intr": test_passed &= verify_external_pll_sources(merge_sources);
             default: begin
                 // For PLL merge interrupts, just verify they have sources
@@ -181,6 +183,18 @@ class comprehensive_merge_sequence extends int_base_sequence;
     virtual function bit verify_abnormal_sources(interrupt_info_s sources[$]);
         string expected_sources[$] = {"iodap_etr_buf_intr", "iodap_catu_addrerr_intr"};
         return verify_sources_contain_expected(sources, expected_sources, "iosub_abnormal_0_intr");
+    endfunction
+
+    virtual function bit verify_abnormal_1_sources(interrupt_info_s sources[$]);
+        // iosub_abnormal_1_intr is a reserved merge signal with no sources
+        // Verify that it has no sources (empty list)
+        if (sources.size() == 0) begin
+            `uvm_info("COMP_MERGE_SEQ", "✅ iosub_abnormal_1_intr correctly has no sources (reserved)", UVM_MEDIUM)
+            return 1;
+        end else begin
+            `uvm_warning("COMP_MERGE_SEQ", $sformatf("iosub_abnormal_1_intr should have no sources but found %0d", sources.size()))
+            return 0;
+        end
     endfunction
     
     virtual function bit verify_external_pll_sources(interrupt_info_s sources[$]);

--- a/tools/verify_merge_implementation.py
+++ b/tools/verify_merge_implementation.py
@@ -86,6 +86,11 @@ def extract_expected_merge_from_csv(csv_file_path):
             "iodap_etr_buf_intr",
             "iodap_catu_addrerr_intr"
         ],
+
+        "iosub_abnormal_1_intr": [
+            # Reserved merge signal with no sources
+            # This is intentionally empty as it's reserved for future use
+        ],
         
         "merge_external_pll_intr": [
             "accel_pll_lock_intr",

--- a/tools/verify_merge_signal_handling.py
+++ b/tools/verify_merge_signal_handling.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""
+验证merge信号处理的脚本
+确保merge类信号不会被直接force/release，而是通过其源信号进行操作
+"""
+
+import re
+import sys
+from pathlib import Path
+
+def get_merge_signals():
+    """获取所有merge信号列表"""
+    return [
+        "merge_pll_intr_lock",
+        "merge_pll_intr_unlock", 
+        "merge_pll_intr_frechangedone",
+        "merge_pll_intr_frechange_tot_done",
+        "merge_pll_intr_intdocfrac_err",
+        "iosub_normal_intr",
+        "iosub_slv_err_intr",
+        "iosub_ras_cri_intr",
+        "iosub_ras_eri_intr",
+        "iosub_ras_fhi_intr",
+        "iosub_abnormal_0_intr",
+        "iosub_abnormal_1_intr",
+        "merge_external_pll_intr"
+    ]
+
+def verify_routing_model():
+    """验证路由模型中merge信号的配置"""
+    print("🔍 验证 seq/int_routing_model.sv 中的merge信号配置...")
+    
+    file_path = Path("seq/int_routing_model.sv")
+    if not file_path.exists():
+        print(f"❌ 文件不存在: {file_path}")
+        return False
+    
+    with open(file_path, 'r', encoding='utf-8') as f:
+        content = f.read()
+    
+    merge_signals = get_merge_signals()
+    success = True
+    
+    # 检查is_merge_interrupt函数是否包含所有merge信号
+    print("\n检查 is_merge_interrupt 函数:")
+    for signal in merge_signals:
+        if f'interrupt_name == "{signal}"' in content:
+            print(f"✅ {signal}: 已在is_merge_interrupt函数中定义")
+        else:
+            print(f"❌ {signal}: 未在is_merge_interrupt函数中定义")
+            success = False
+    
+    # 检查get_merge_sources函数是否包含所有merge信号的处理逻辑
+    print("\n检查 get_merge_sources 函数:")
+    for signal in merge_signals:
+        if f'"{signal}":' in content:
+            print(f"✅ {signal}: 已在get_merge_sources函数中定义")
+        else:
+            print(f"❌ {signal}: 未在get_merge_sources函数中定义")
+            success = False
+    
+    return success
+
+def verify_driver_handling():
+    """验证驱动器中merge信号的处理"""
+    print("\n🔍 验证 env/int_driver.sv 中merge信号的处理...")
+    
+    file_path = Path("env/int_driver.sv")
+    if not file_path.exists():
+        print(f"❌ 文件不存在: {file_path}")
+        return False
+    
+    with open(file_path, 'r', encoding='utf-8') as f:
+        content = f.read()
+    
+    # 检查是否有对merge信号的特殊处理
+    # 通常merge信号不应该被直接force/release
+    merge_signals = get_merge_signals()
+    
+    print("检查驱动器是否正确处理merge信号:")
+    
+    # 查找可能的merge信号处理逻辑
+    if "is_merge_interrupt" in content:
+        print("✅ 驱动器中包含merge信号检查逻辑")
+        return True
+    else:
+        print("⚠️  驱动器中未发现merge信号检查逻辑")
+        print("   建议在驱动器中添加merge信号检查，避免直接force/release merge信号")
+        return False
+
+def verify_test_coverage():
+    """验证测试覆盖率"""
+    print("\n🔍 验证测试文件中merge信号的覆盖...")
+    
+    file_path = Path("test/tc_comprehensive_merge_test.sv")
+    if not file_path.exists():
+        print(f"❌ 文件不存在: {file_path}")
+        return False
+    
+    with open(file_path, 'r', encoding='utf-8') as f:
+        content = f.read()
+    
+    merge_signals = get_merge_signals()
+    success = True
+    
+    print("检查测试文件中的merge信号覆盖:")
+    for signal in merge_signals:
+        if f'"{signal}"' in content:
+            print(f"✅ {signal}: 已包含在测试中")
+        else:
+            print(f"❌ {signal}: 未包含在测试中")
+            success = False
+    
+    return success
+
+def check_abnormal_signals_specifically():
+    """专门检查abnormal信号的配置"""
+    print("\n🔍 专门检查 iosub_abnormal_0_intr 和 iosub_abnormal_1_intr 的配置...")
+    
+    # 检查int_map_entries.svh中的配置
+    file_path = Path("seq/int_map_entries.svh")
+    if not file_path.exists():
+        print(f"❌ 文件不存在: {file_path}")
+        return False
+    
+    with open(file_path, 'r', encoding='utf-8') as f:
+        content = f.read()
+    
+    success = True
+    
+    # 检查iosub_abnormal_0_intr的配置
+    pattern_0 = r'name:"iosub_abnormal_0_intr".*?index:74'
+    if re.search(pattern_0, content):
+        print("✅ iosub_abnormal_0_intr: 在index 74处正确配置")
+    else:
+        print("❌ iosub_abnormal_0_intr: 配置不正确")
+        success = False
+    
+    # 检查iosub_abnormal_1_intr的配置
+    pattern_1 = r'name:"iosub_abnormal_1_intr".*?index:75'
+    if re.search(pattern_1, content):
+        print("✅ iosub_abnormal_1_intr: 在index 75处正确配置")
+    else:
+        print("❌ iosub_abnormal_1_intr: 配置不正确")
+        success = False
+    
+    return success
+
+def main():
+    """主函数"""
+    print("=" * 60)
+    print("🔧 验证merge信号处理配置")
+    print("=" * 60)
+    
+    success = True
+    
+    # 验证路由模型
+    success &= verify_routing_model()
+    
+    # 验证驱动器处理
+    success &= verify_driver_handling()
+    
+    # 验证测试覆盖
+    success &= verify_test_coverage()
+    
+    # 专门检查abnormal信号
+    success &= check_abnormal_signals_specifically()
+    
+    print("\n" + "=" * 60)
+    if success:
+        print("🎉 验证成功！merge信号处理配置正确")
+        print("\n主要修改:")
+        print("  1. iosub_abnormal_0_intr: 已正确配置为merge信号")
+        print("  2. iosub_abnormal_1_intr: 已添加为reserved merge信号")
+        print("  3. 路由模型: 已更新包含两个abnormal信号")
+        print("  4. 测试覆盖: 已包含新的merge信号")
+        print("\n这应该解决UVM_ERROR中的HDL路径定位问题")
+    else:
+        print("❌ 验证失败！请检查上述错误并修复")
+        sys.exit(1)
+    
+    print("=" * 60)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem Description

Fixed two UVM_ERROR issues related to HDL path location failures:

```
120:12994:UVM_ERROR [...] set: unable to locate hdl path (top_tb.multidie_top.DUT[0].u_str_top.u_iosub_top_wrap.u0_iosub_top_wrap_hd.u0_iosub_top_wrap_raw.u_iosub_int_sub.iosub_peri_intr[74])
120:12994:UVM_ERROR [...] set: unable to locate hdl path (top_tb.multidie_top.DUT[0].u_str_top.u_iosub_top_wrap.u0_iosub_top_wrap_hd.u0_iosub_top_wrap_raw.u_iosub_int_sub.iosub_peri_intr[75])
```

## Root Cause Analysis

1. **iosub_abnormal_0_intr** (index 74) was configured as a merge signal but the system was still trying to directly force/release its RTL path
2. **iosub_abnormal_1_intr** (index 75) should be added as a merge class signal but was missing from the merge signal configuration

## Solution

### 1. Enhanced Merge Signal Handling
- Added `iosub_abnormal_1_intr` as a reserved merge signal with no sources
- Updated routing model to properly handle both abnormal signals
- Added driver protection to prevent direct stimulation of merge signals

### 2. Driver Protection
- Added merge signal detection in `int_driver.sv`
- Prevents direct force/release operations on merge signals
- Provides helpful guidance to stimulate source signals instead

### 3. Complete Test Coverage
- Updated comprehensive merge tests to include `iosub_abnormal_1_intr`
- Added verification functions for reserved merge signals
- Enhanced verification scripts

## Files Changed

- `seq/int_routing_model.sv` - Added merge signal handling for iosub_abnormal_1_intr
- `env/int_driver.sv` - Added merge signal protection logic
- `test/tc_comprehensive_merge_test.sv` - Updated test coverage
- `tools/verify_merge_implementation.py` - Updated verification script
- `tools/verify_merge_signal_handling.py` - New verification tool
- `docs/fix_iosub_abnormal_merge_signals.md` - Documentation

## Verification

✅ All merge signals properly configured in routing model  
✅ Driver includes merge signal protection  
✅ Complete test coverage for all merge signals  
✅ Verification scripts confirm correct implementation  

## Expected Impact

- **Resolves UVM_ERROR**: Merge signals no longer directly forced/released
- **Proper merge handling**: Source signals used to test merge functionality
- **Future-proof**: iosub_abnormal_1_intr ready for future use as reserved signal
- **Better guidance**: Clear warnings when attempting to stimulate merge signals

## Testing

To test `iosub_abnormal_0_intr`, stimulate its source signals:
- `iodap_etr_buf_intr`
- `iodap_catu_addrerr_intr`

`iosub_abnormal_1_intr` is reserved with no sources but properly configured for future use.

## Verification Commands

```bash
# Verify merge signal handling
python3 tools/verify_merge_signal_handling.py

# Verify merge implementation
python3 tools/verify_merge_implementation.py
```

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author