### PR TITLE
Fix scope resolution error in int_routing_model.sv

### DIFF
--- a/seq/int_routing_model.sv
+++ b/seq/int_routing_model.sv
@@ -312,7 +312,7 @@ class int_routing_model;
         if (!routing_enabled) return 0;
 
         // Check if interrupt is masked (returns 1 if masked, 0 if enabled)
-        mask_enabled = !int_register_model::is_interrupt_masked(interrupt_name, destination);
+        mask_enabled = !is_interrupt_masked(interrupt_name, destination);
 
         // Interrupt will be routed if both routing is enabled AND mask is enabled
         return (routing_enabled && mask_enabled);
@@ -341,7 +341,7 @@ class int_routing_model;
     // Function to update status registers when interrupt occurs
     static function void update_interrupt_status(string interrupt_name, bit status_value);
         // Update the register model status
-        int_register_model::update_status_register(interrupt_name, status_value);
+        update_status_register(interrupt_name, status_value);
 
         // Log the status update
         `uvm_info("INT_ROUTING_MODEL", $sformatf("Updated status for interrupt '%s' to %b",
@@ -369,7 +369,7 @@ class int_routing_model;
         string all_destinations[$] = {"AP", "SCP", "MCP", "IMU", "IO", "OTHER_DIE"};
         foreach (all_destinations[i]) begin
             bit routing_enabled = predict_interrupt_routing_with_mask(interrupt_name, all_destinations[i]);
-            bit mask_status = !int_register_model::is_interrupt_masked(interrupt_name, all_destinations[i]);
+            bit mask_status = !is_interrupt_masked(interrupt_name, all_destinations[i]);
             `uvm_info("INT_ROUTING_MODEL", $sformatf("  %s: routing=%b, mask_enabled=%b, final=%b",
                       all_destinations[i],
                       (all_destinations[i] == "AP") ? info.to_ap :


### PR DESCRIPTION
## Problem

The compilation was failing with the following error:
```
Error-[SV-EEM-SRE] Scope resolution error
/share/project/greenland/dev/wenbo.liu/ws3/dv/iosub/soc_top/subenv/int_subenv/seq/int_routing_model.sv, 317
int_subenv_pkg, "int_register_model::is_interrupt_masked"
  Target for scope resolution operator does not exist. Token 
  'int_register_model' is not a class/package.  Originating module 
  'int_subenv_pkg'.
```

## Root Cause

The issue was caused by unnecessary use of scope resolution operator (`::`) when calling functions from `int_register_model` class within `int_routing_model.sv`. Since both classes are included in the same package (`int_subenv_pkg`), they share the same scope and don't require scope resolution.

## Solution

Removed the scope resolution operator from three function calls:

1. **Line 315**: `int_register_model::is_interrupt_masked()` → `is_interrupt_masked()`
2. **Line 344**: `int_register_model::update_status_register()` → `update_status_register()`
3. **Line 372**: `int_register_model::is_interrupt_masked()` → `is_interrupt_masked()`

## Testing

- [x] Verified that both `is_interrupt_masked` and `update_status_register` functions exist in `int_register_model` class
- [x] Confirmed that both classes are properly included in `int_subenv_pkg`
- [x] No other instances of this scope resolution issue found in the file

## Files Changed

- `seq/int_routing_model.sv` - Removed unnecessary scope resolution operators

This is a simple compilation fix that maintains the same functionality while resolving the SystemVerilog scope resolution error.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author