### PR TITLE
Fix: Skip interrupts with no routing destinations in lightweight sequence

### DIFF
--- a/PROJECT_STATUS_SUMMARY.md
+++ b/PROJECT_STATUS_SUMMARY.md
@@ -7,7 +7,8 @@
 **完成度**: 98% (所有子系统mask支持完成，待DUT适配)
 **最后更新**: 2025-07-30
 
-### 🆕 最新更新 (2025-08-01)
+### 🆕 最新更新 (2025-08-05)
+✅ **修复lightweight_sequence中断激励逻辑** - 修复对无路由目的地中断的错误激励问题
 ✅ **修复IOSUB RAS Merge逻辑** - iosub_ras_*_intr现在仅merge smmu的ras中断，简化merge逻辑
 ✅ **修复Mask一致性问题** - 统一add_expected_with_mask和wait_for_interrupt_detection的mask逻辑
 ✅ **统一ACCEL和IMU术语** - 移除所有IMU引用，统一使用ACCEL

--- a/docs/lightweight_sequence_fix_summary.md
+++ b/docs/lightweight_sequence_fix_summary.md
@@ -1,0 +1,165 @@
+# Lightweight Sequence 中断激励逻辑修复总结
+
+## 📋 问题描述
+
+在 `int_lightweight_sequence.sv` 的执行过程中，发现了一个关键的逻辑错误：
+
+**问题现象**：当某个中断对所有目的地都不会路由时（即所有 `to_*` 字段都为0），系统依然会对该中断施加激励。
+
+**问题根因**：这种情况下的中断实际上属于merge类型中断的源中断，应该在merge中断激励过程中进行处理，而不是在单独的中断激励中处理。
+
+## 🔍 技术分析
+
+### 原始逻辑问题
+
+在修复前的 `should_skip_interrupt_check` 函数中：
+
+```systemverilog
+// 原始逻辑
+bit has_other_destinations = 0;
+
+// 检查是否有除 other_die 和 io 之外的目的地
+if (info.to_ap || info.to_scp || info.to_mcp || info.to_accel) begin
+    has_other_destinations = 1;
+end
+
+// 只有当中断仅路由到 other_die 或 io 时才跳过
+if (!has_other_destinations && (info.to_other_die || info.to_io)) begin
+    return 1; // 跳过
+end
+```
+
+**问题分析**：
+- 当中断所有 `to_*` 字段都为0时，`has_other_destinations = 0`
+- 由于 `to_other_die` 和 `to_io` 也为0，条件 `!has_other_destinations && (info.to_other_die || info.to_io)` 不成立
+- 结果：这种中断不会被跳过，依然会施加激励
+
+### 修复后的逻辑
+
+```systemverilog
+// 修复后的逻辑
+bit has_any_destinations = 0;
+bit has_other_destinations = 0;
+
+// 检查是否有任何目的地
+if (info.to_ap || info.to_scp || info.to_mcp || info.to_accel || info.to_io || info.to_other_die) begin
+    has_any_destinations = 1;
+end
+
+// 跳过没有任何目的地的中断 - 它们是merge源中断
+if (!has_any_destinations) begin
+    `uvm_info(get_type_name(), $sformatf("Skipping interrupt '%s' - no routing destinations (merge source)",
+             info.name), UVM_MEDIUM)
+    return 1;
+end
+```
+
+## 🛠️ 修复内容
+
+### 1. 新增检查逻辑
+
+在 `should_skip_interrupt_check` 函数中添加了新的检查：
+
+- **新增变量**：`has_any_destinations` - 检查中断是否有任何路由目的地
+- **新增条件**：如果中断没有任何路由目的地，则跳过该中断
+- **日志输出**：明确标识跳过的原因为"merge source"
+
+### 2. 保持现有逻辑
+
+修复保持了所有现有的跳过逻辑：
+- 跳过仅路由到 `other_die` 或 `io` 的中断
+- 跳过从SCP发出且仅路由到SCP的中断  
+- 跳过从MCP发出且仅路由到MCP的中断
+
+### 3. 代码变更详情
+
+**文件**：`seq/int_lightweight_sequence.sv`
+**函数**：`should_skip_interrupt_check`
+**行数**：第13-65行
+
+**主要变更**：
+1. 添加 `has_any_destinations` 变量
+2. 添加全面的目的地检查逻辑
+3. 在现有检查之前添加无目的地中断的跳过逻辑
+4. 更新注释说明新的跳过条件
+
+## 🎯 修复效果
+
+### 预期改进
+
+1. **正确处理merge源中断**：
+   - 无路由目的地的中断将被正确跳过
+   - 这些中断将在merge中断处理逻辑中得到适当的激励
+
+2. **避免重复激励**：
+   - 防止merge源中断在单独激励和merge激励中被重复处理
+   - 提高测试效率和准确性
+
+3. **更清晰的日志输出**：
+   - 明确标识跳过原因为"merge source"
+   - 便于调试和问题追踪
+
+### 兼容性保证
+
+- **向后兼容**：所有现有的跳过逻辑保持不变
+- **功能完整性**：不影响正常中断的激励和检测
+- **测试覆盖率**：不降低现有的测试覆盖范围
+
+## 📊 影响评估
+
+### 正面影响
+
+1. **逻辑正确性**：修复了中断激励逻辑的根本缺陷
+2. **性能优化**：减少了不必要的激励操作
+3. **代码质量**：提高了代码的逻辑清晰度
+
+### 风险评估
+
+- **风险等级**：低
+- **影响范围**：仅影响无路由目的地的中断处理
+- **回退方案**：可以通过版本控制轻松回退
+
+## 🧪 验证建议
+
+### 测试重点
+
+1. **merge中断测试**：
+   - 验证merge源中断不会被单独激励
+   - 确认merge中断逻辑正常工作
+
+2. **正常中断测试**：
+   - 验证有路由目的地的中断正常激励
+   - 确认现有跳过逻辑仍然有效
+
+3. **边界条件测试**：
+   - 测试各种路由配置组合
+   - 验证日志输出的正确性
+
+### 推荐测试用例
+
+```bash
+# 运行merge中断相关测试
+make test TEST=tc_merge_interrupt_test
+
+# 运行综合merge测试
+make test TEST=tc_comprehensive_merge_test
+
+# 运行路由测试
+make test TEST=tc_int_routing
+```
+
+## 📝 总结
+
+这次修复解决了 `lightweight_sequence` 中一个重要的逻辑缺陷，确保了：
+
+1. **正确的中断分类**：merge源中断不会被错误地单独激励
+2. **逻辑一致性**：中断处理逻辑与硬件架构保持一致
+3. **代码健壮性**：提高了验证环境的可靠性
+
+修复后的代码更加符合中断系统的设计意图，为后续的DUT集成和验证工作奠定了更坚实的基础。
+
+---
+**修复日期**：2025-08-05  
+**修复人员**：Augment Agent  
+**审核状态**：待审核  
+**版本标签**：v1.1-interrupt-fix


### PR DESCRIPTION
## 🔧 Problem Fixed

Fixed a critical logic issue in `int_lightweight_sequence.sv` where interrupts with no routing destinations were incorrectly being stimulated. These interrupts are actually merge source interrupts and should be handled in the merge interrupt logic, not in individual stimulus.

## 📋 Root Cause

When an interrupt has all `to_*` fields set to 0 (no routing destinations), the original logic would:
- Set `has_other_destinations = 0`
- Since `to_other_die` and `to_io` are also 0, the skip condition `!has_other_destinations && (info.to_other_die || info.to_io)` would not be met
- Result: The interrupt would still be stimulated incorrectly

## 🛠️ Solution

Added a new check in `should_skip_interrupt_check()` function:

```systemverilog
// Check if interrupt has any destinations at all
if (info.to_ap || info.to_scp || info.to_mcp || info.to_accel || info.to_io || info.to_other_die) begin
    has_any_destinations = 1;
end

// Skip interrupts with no destinations - they are merge sources
if (!has_any_destinations) begin
    `uvm_info(get_type_name(), $sformatf("Skipping interrupt '%s' - no routing destinations (merge source)",
             info.name), UVM_MEDIUM)
    return 1;
end
```

## 📁 Files Changed

- **`seq/int_lightweight_sequence.sv`**: Added logic to skip no-destination interrupts
- **`PROJECT_STATUS_SUMMARY.md`**: Updated project status with fix details
- **`docs/lightweight_sequence_fix_summary.md`**: Added comprehensive technical documentation

## 🎯 Benefits

1. **Correct Logic**: Merge source interrupts are no longer incorrectly stimulated
2. **Performance**: Reduces unnecessary stimulus operations
3. **Accuracy**: Improves test accuracy and reliability
4. **Backward Compatible**: All existing skip logic remains unchanged
5. **Clear Logging**: Added specific log messages for debugging

## 🧪 Testing Recommendations

Suggested tests to verify the fix:

```bash
# Test merge interrupt logic
make test TEST=tc_merge_interrupt_test
make test TEST=tc_comprehensive_merge_test

# Test routing logic
make test TEST=tc_int_routing
```

## 📊 Impact Assessment

- **Risk Level**: Low
- **Scope**: Only affects interrupts with no routing destinations
- **Compatibility**: Fully backward compatible
- **Quality**: Improves code logic and reliability

## 🔍 Technical Details

For detailed technical analysis, see the new documentation:
- `docs/lightweight_sequence_fix_summary.md`

This fix ensures that interrupt stimulus logic aligns with the hardware architecture and prevents duplicate handling of merge source interrupts.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author